### PR TITLE
feat(tools): 添加绝区零驱动盘数据爬取工具

### DIFF
--- a/src/docs/tools/drive-disk-rating/README.md
+++ b/src/docs/tools/drive-disk-rating/README.md
@@ -1,0 +1,83 @@
+# Zenless Zone Zero 驱动盘数据爬取工具
+
+## 功能介绍
+
+本工具用于获取《绝区零》(Zenless Zone Zero)游戏中登录账号的角色驱动盘数据。采用API调用方式获取数据，相比传统的页面元素提取方式更加可靠和高效。
+
+### 核心功能
+
+- 自动获取当前登录账号UID
+- 读取所有已解锁角色信息
+- 批量获取装备（驱动盘）与音擎（武器）信息
+- 输出结构化的完整练度数据
+- 支持数据导出为JSON格式
+
+## 安装说明
+
+### 方式1:
+
+#### 1. 安装Python依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+#### 2. 下载EdgeDriver
+
+- 确保已安装Edge浏览器
+- 从[EdgeDriver官网](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)下载与Edge浏览器版本匹配的EdgeDriver
+- 解压后得到可执行文件
+
+### 方式2:
+
+下载并打开drive_disc_oneclick.html，按照上面的指引完成操作。无需安装Python依赖。
+
+## 使用方法(只针对方式1)
+
+### 基本使用
+
+```bash
+python zzz_driver_disc_scraper.py
+```
+
+### 指定EdgeDriver路径
+
+如果系统无法自动找到EdgeDriver，可以手动指定路径：
+
+```bash
+python zzz_driver_disc_scraper.py --edgedriver "C:\path\to\msedgedriver.exe"
+```
+
+### 详细步骤
+
+1. 运行脚本后，会自动打开Edge浏览器并访问目标网站
+2. 在浏览器中完成登录操作
+3. 登录完成后，在命令行窗口按Enter键继续
+4. 脚本会自动爬取所有角色的驱动盘数据
+5. 数据会保存为`driver_disc_data.json`文件
+
+## 注意事项
+
+1. 本工具仅用于学习和研究目的
+2. 使用时请遵守相关网站的使用条款
+3. 登录操作需要手动完成
+4. 数据爬取可能需要较长时间，请耐心等待
+5. 如果API接口发生变化，可能需要更新代码中的API调用部分
+
+## 文件说明
+
+- `zzz_driver_disc_scraper.py`: 主程序文件
+- `requirements.txt`: 依赖包列表
+- `drive_disc_oneclick.html`: 一键提取数据的HTML页面
+- `driver_disc_data.json`: 爬取的数据文件（运行后生成）
+
+## 常见问题
+
+### Q: EdgeDriver找不到怎么办？
+A: 请确保Edge浏览器已安装，并从官网下载对应版本的EdgeDriver，然后使用`--edgedriver`参数指定路径。
+
+### Q: 登录后无法爬取数据？
+A: 请确保登录完成后再按Enter键，或者检查网络连接是否正常。
+
+### Q: 爬取的数据为空？
+A: 可能是API接口发生变化，需要更新代码中的API调用部分，或者登录状态已失效，请重新登录。

--- a/src/docs/tools/drive-disk-rating/drive_disc_oneclick.html
+++ b/src/docs/tools/drive-disk-rating/drive_disc_oneclick.html
@@ -1,0 +1,780 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>绝区零驱动盘一键提取工具</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 20px;
+            color: #333;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            overflow: hidden;
+        }
+
+        .header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 30px;
+            text-align: center;
+        }
+
+        .header h1 {
+            font-size: 28px;
+            margin-bottom: 10px;
+        }
+
+        .header p {
+            opacity: 0.9;
+            font-size: 14px;
+        }
+
+        .content {
+            padding: 30px;
+        }
+
+        .step {
+            background: #f8f9fa;
+            border-left: 4px solid #667eea;
+            padding: 20px;
+            margin-bottom: 20px;
+            border-radius: 0 8px 8px 0;
+        }
+
+        .step h3 {
+            color: #667eea;
+            margin-bottom: 10px;
+            font-size: 18px;
+        }
+
+        .step p {
+            line-height: 1.6;
+            color: #555;
+            margin-bottom: 10px;
+        }
+
+        .step code {
+            background: #e9ecef;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: "Consolas", "Monaco", monospace;
+            font-size: 13px;
+            color: #d63384;
+        }
+
+        .bookmarklet {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 15px 30px;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: bold;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+            transition: transform 0.2s, box-shadow 0.2s;
+            margin: 10px 5px;
+            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+        }
+
+        .bookmarklet:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+        }
+
+        .bookmarklet:active {
+            transform: translateY(0);
+        }
+
+        .btn {
+            display: inline-block;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 12px 30px;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            cursor: pointer;
+            text-decoration: none;
+            transition: transform 0.2s, box-shadow 0.2s;
+            margin: 10px 5px;
+        }
+
+        .btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
+        }
+
+        .btn-secondary {
+            background: #6c757d;
+        }
+
+        .result-area {
+            background: #f8f9fa;
+            border: 2px dashed #dee2e6;
+            border-radius: 8px;
+            padding: 20px;
+            margin-top: 20px;
+            min-height: 200px;
+        }
+
+        .result-area h3 {
+            margin-bottom: 15px;
+            color: #495057;
+        }
+
+        .result-content {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            font-family: "Consolas", "Monaco", monospace;
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-break: break-all;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 0 6px 6px 0;
+        }
+
+        .warning strong {
+            color: #856404;
+        }
+
+        .success {
+            background: #d4edda;
+            border-left: 4px solid #28a745;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 0 6px 6px 0;
+            color: #155724;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .info-box {
+            background: #e7f3ff;
+            border-left: 4px solid #2196F3;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 0 6px 6px 0;
+        }
+
+        .info-box strong {
+            color: #1976D2;
+        }
+
+        .number-list {
+            counter-reset: step-counter;
+            list-style: none;
+            padding-left: 0;
+        }
+
+        .number-list li {
+            position: relative;
+            padding-left: 40px;
+            margin-bottom: 15px;
+            line-height: 1.6;
+        }
+
+        .number-list li::before {
+            counter-increment: step-counter;
+            content: counter(step-counter);
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 28px;
+            height: 28px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            font-size: 14px;
+        }
+
+        .highlight {
+            background: #fff3cd;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+        }
+
+        .loading {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 3px solid rgba(255,255,255,.3);
+            border-radius: 50%;
+            border-top-color: #fff;
+            animation: spin 1s ease-in-out infinite;
+            margin-right: 10px;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>绝区零驱动盘一键提取工具</h1>
+            <p>使用书签脚本，在官方页面一键提取驱动盘数据</p>
+        </div>
+
+        <div class="content">
+            <div class="step">
+                <h3>📖 使用说明</h3>
+                <p>本工具使用书签脚本技术，让您在绝区零官方页面一键提取驱动盘数据，无需手动复制粘贴。</p>
+                
+                <div class="info-box">
+                    <strong>💡 什么是书签脚本？</strong>
+                    <p style="margin-top: 8px;">书签脚本是一个特殊的浏览器书签，点击后会在当前页面执行 JavaScript 代码，实现自动化操作。</p>
+                </div>
+            </div>
+
+            <div class="step">
+                <h3>🚀 一键提取步骤</h3>
+                <ul class="number-list">
+                    <li>
+                        <strong>访问官方页面</strong><br>
+                        点击下方按钮打开绝区零角色练度页面，并确保您已登录账号。
+                        <div style="margin-top: 10px;">
+                            <a href="https://act.mihoyo.com/zzz/gt/character-builder-h/index.html#/" target="_blank" class="btn">
+                                打开角色练度页面 ↗
+                            </a>
+                        </div>
+                    </li>
+                    <li>
+                        <strong>添加书签脚本</strong><br>
+                        <span class="highlight">拖拽</span> 下方的按钮到浏览器的书签栏中，或者右键点击按钮选择"添加到书签"。
+                        <div style="margin-top: 10px;">
+                            <a href="javascript:(async function(){const API_BASE='https://act-api-takumi.mihoyo.com/event/nap_cultivate_tool';const API_LOGIN='https://api-takumi.mihoyo.com/common/badge/v1/login/info';const cleanText=t=>t?.replace(/<[^>]*>/g,'').replace(/\\n/g,'')||'';const fetchJSON=(t,e)=>fetch(t,{credentials:'include',...e}).then(t=>t.json());const getGameUID=async()=>(await fetchJSON(`${API_LOGIN}?game_biz=nap_cn&lang=zh-cn`)).data?.game_uid;const getDeviceFP=()=>document.cookie.match(/DEVICEFP=(\w+)/)?.[1];const getBasicList=(t,e)=>fetchJSON(`${API_BASE}/user/avatar_basic_list?uid=${t}&region=prod_gf_cn`,{headers:{'x-rpc-device_fp':e}});const getEquipBatch=(t,e,o)=>fetchJSON(`${API_BASE}/user/batch_avatar_detail_v2?uid=${t}&region=prod_gf_cn`,{method:'POST',headers:{'x-rpc-device_fp':o},body:JSON.stringify({avatar_list:e})});const processEquipData=({avatar:t,equip:e,weapon:o})=>({characterName:t.name_mi18n,characterFullName:t.full_name_mi18n,level:t.level,profession:t.avatar_profession,driveDiscs:e?.map(({level:t,name:e,icon:o,rarity:a,invalid_property_cnt:i,equipment_type:s,properties:r,main_properties:n,equip_suit:c})=>({position:s,name:e,level:t,rarity:a,invalidProperty:i,mainProperty:{name:n[0].property_name,val:n[0].base},subProperties:r.map(({property_name:t,base:e,level:o,valid:a,add:i})=>({name:t,val:e,level:o,valid:a,add:i})),suit:{name:c.name,desc1:c.desc1,desc2:cleanText(c.desc2)}}))||[]});const uid=await getGameUID();const device_fp=getDeviceFP();if(!uid||!device_fp){alert('❌ 无法读取 UID 或 DEVICEFP，可能未登录！');return;}const basicData=await getBasicList(uid,device_fp);const avatarList=basicData.data.list.filter(t=>t.unlocked).map(t=>({avatar_id:t.avatar.id}));const batches=[];for(let t=0;t<avatarList.length;t+=10)batches.push(avatarList.slice(t,t+10));const detailResponses=await Promise.all(batches.map(t=>getEquipBatch(uid,t,device_fp)));const allResults=detailResponses.flatMap(t=>t.data.list.map(processEquipData));const result=allResults.map(t=>({characterName:t.characterName,characterFullName:t.characterFullName,level:t.level,profession:t.profession,driveDiscs:t.driveDiscs.map(e=>({position:e.position,name:e.name,level:e.level,rarity:e.rarity,invalidProperty:e.invalidProperty,mainProperty:{name:e.mainProperty.name,value:e.mainProperty.val},subProperties:e.subProperties.map(t=>({name:t.name,value:t.val,level:t.level,valid:t.valid,add:t.add})),suit:{name:e.suit.name,desc1:e.suit.desc1,desc2:e.suit.desc2}}))}));const jsonResult=JSON.stringify(result,null,2);const blob=new Blob([jsonResult],{type:'application/json'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download='drive_discs_data.json';document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);alert('✅ 驱动盘数据提取成功！已自动下载为 drive_discs_data.json');console.log('📊 提取结果：',result);})();" class="bookmarklet" title="拖拽此按钮到书签栏">
+                                🎮 一键提取驱动盘
+                            </a>
+                        </div>
+                        <p style="margin-top: 8px; font-size: 13px; color: #666;">
+                            💡 提示：如果看不到书签栏，按 <code>Ctrl+Shift+B</code> (Windows) 或 <code>Cmd+Shift+B</code> (Mac) 显示
+                        </p>
+                    </li>
+                    <li>
+                        <strong>一键提取数据</strong><br>
+                        在官方页面点击书签栏中的 <span class="highlight">"🎮 一键提取驱动盘"</span> 按钮，脚本将自动提取所有角色的驱动盘数据并下载为 JSON 文件。
+                    </li>
+                </ul>
+            </div>
+
+            <div class="warning">
+                <strong>⚠️ 注意事项：</strong>
+                <ul style="margin-left: 20px; margin-top: 10px;">
+                    <li>确保您已在官方页面登录绝区零账号</li>
+                    <li>提取的数据仅保存在本地，不会上传到任何服务器</li>
+                    <li>首次使用可能需要几秒钟时间，请耐心等待</li>
+                    <li>如果遇到错误，请检查网络连接和登录状态</li>
+                    <li>建议使用 Chrome、Edge 或 Firefox 浏览器</li>
+                </ul>
+            </div>
+
+            <div class="step">
+                <h3>📊 数据格式说明</h3>
+                <p>以下是JSON数据中各字段的详细说明：</p>
+                <table style="width: 100%; border-collapse: collapse; margin-bottom: 15px; font-size: 13px;">
+                    <thead>
+                        <tr style="background-color: #f2f2f2;">
+                            <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">字段路径</th>
+                            <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">类型</th>
+                            <th style="border: 1px solid #ddd; padding: 8px; text-align: left;">说明</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- 角色基本信息 -->
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>characterName</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">字符串</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">角色名称</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>characterFullName</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">字符串</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">角色全名</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>level</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数字</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">角色等级</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>profession</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数字</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">职业类型（1-6）</td>
+                        </tr>
+                        
+                        <!-- 驱动盘基本信息 -->
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].position</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数字</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">驱动盘位置（1-6）</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].name</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">字符串</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">驱动盘名称</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].level</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数字</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">驱动盘强化等级</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].rarity</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">字符串</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">稀有度（S、A、B、C）</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].invalidProperty</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数字</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">无效属性数量</td>
+                        </tr>
+                        
+                        <!-- 属性信息 -->
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].mainProperty</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">对象</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">主属性信息</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].subProperties</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数组</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">副属性列表</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].subProperties[].valid</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">布尔值</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">属性是否有效</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].subProperties[].level</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">数字</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">属性强化等级</td>
+                        </tr>
+                        
+                        <!-- 套装信息 -->
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].suit</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">对象</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">套装信息</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].suit.desc1</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">字符串</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">2件套装效果</td>
+                        </tr>
+                        <tr>
+                            <td style="border: 1px solid #ddd; padding: 8px;"><code>driveDiscs[].suit.desc2</code></td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">字符串</td>
+                            <td style="border: 1px solid #ddd; padding: 8px;">4件套装效果</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>提取的 JSON 文件包含以下完整结构（以角色"悠真"为例）：</p>
+                <pre style="background: #2d2d2d; color: #f8f8f2; padding: 15px; border-radius: 6px; overflow-x: auto; font-size: 12px; line-height: 1.5;">
+[
+  {
+    "characterName": "悠真",
+    "characterFullName": "浅羽 悠真",
+    "level": 40,
+    "profession": 1,
+    "driveDiscs": [
+      {
+        "position": 1,
+        "name": "啄木鸟电音[1]",
+        "level": 3,
+        "rarity": "A",
+        "invalidProperty": 0,
+        "mainProperty": {
+          "name": "生命值",
+          "value": "642"
+        },
+        "subProperties": [
+          {
+            "name": "防御力",
+            "value": "3.2%",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "生命值",
+            "value": "2%",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "攻击力",
+            "value": "2%",
+            "level": 1,
+            "valid": true,
+            "add": 0
+          }
+        ],
+        "suit": {
+          "name": "啄木鸟电音",
+          "desc1": "暴击率+8%。",
+          "desc2": "[普通攻击]、[闪避反击]或[强化特殊技]命中敌人并触发暴击时，分别为装备者提供1层增益效果，每层增益效果使装备者的攻击力提升9%，持续6秒，不同招式分别结算持续时间。"
+        }
+      },
+      {
+        "position": 2,
+        "name": "啄木鸟电音[2]",
+        "level": 6,
+        "rarity": "A",
+        "invalidProperty": 0,
+        "mainProperty": {
+          "name": "攻击力",
+          "value": "132"
+        },
+        "subProperties": [
+          {
+            "name": "防御力",
+            "value": "10",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "异常精通",
+            "value": "6",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "生命值",
+            "value": "75",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "防御力",
+            "value": "3.2%",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          }
+        ],
+        "suit": {
+          "name": "啄木鸟电音",
+          "desc1": "暴击率+8%。",
+          "desc2": "[普通攻击]、[闪避反击]或[强化特殊技]命中敌人并触发暴击时，分别为装备者提供1层增益效果，每层增益效果使装备者的攻击力提升9%，持续6秒，不同招式分别结算持续时间。"
+        }
+      },
+      {
+        "position": 3,
+        "name": "啄木鸟电音[3]",
+        "level": 0,
+        "rarity": "A",
+        "invalidProperty": 0,
+        "mainProperty": {
+          "name": "防御力",
+          "value": "31"
+        },
+        "subProperties": [
+          {
+            "name": "防御力",
+            "value": "3.2%",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "暴击率",
+            "value": "1.6%",
+            "level": 1,
+            "valid": true,
+            "add": 0
+          }
+        ],
+        "suit": {
+          "name": "啄木鸟电音",
+          "desc1": "暴击率+8%。",
+          "desc2": "[普通攻击]、[闪避反击]或[强化特殊技]命中敌人并触发暴击时，分别为装备者提供1层增益效果，每层增益效果使装备者的攻击力提升9%，持续6秒，不同招式分别结算持续时间。"
+        }
+      },
+      {
+        "position": 4,
+        "name": "啄木鸟电音[4]",
+        "level": 0,
+        "rarity": "A",
+        "invalidProperty": 0,
+        "mainProperty": {
+          "name": "暴击率",
+          "value": "4%"
+        },
+        "subProperties": [
+          {
+            "name": "暴击伤害",
+            "value": "3.2%",
+            "level": 1,
+            "valid": true,
+            "add": 0
+          },
+          {
+            "name": "异常精通",
+            "value": "6",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "攻击力",
+            "value": "13",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          }
+        ],
+        "suit": {
+          "name": "啄木鸟电音",
+          "desc1": "暴击率+8%。",
+          "desc2": "[普通攻击]、[闪避反击]或[强化特殊技]命中敌人并触发暴击时，分别为装备者提供1层增益效果，每层增益效果使装备者的攻击力提升9%，持续6秒，不同招式分别结算持续时间。"
+        }
+      },
+      {
+        "position": 5,
+        "name": "混沌重金属[5]",
+        "level": 0,
+        "rarity": "B",
+        "invalidProperty": 0,
+        "mainProperty": {
+          "name": "物理伤害加成",
+          "value": "2.5%"
+        },
+        "subProperties": [
+          {
+            "name": "生命值",
+            "value": "1%",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          }
+        ],
+        "suit": {
+          "name": "混沌重金属",
+          "desc1": "以太伤害+10%。",
+          "desc2": "装备者的暴击伤害提升20%，队伍中任意角色触发[侵蚀]效果的额外伤害时，该增益效果额外提升5.5%，最多叠加6层，持续8秒，重复触发时刷新持续时间。"
+        }
+      },
+      {
+        "position": 6,
+        "name": "震星迪斯科[6]",
+        "level": 0,
+        "rarity": "B",
+        "invalidProperty": 0,
+        "mainProperty": {
+          "name": "生命值",
+          "value": "2.5%"
+        },
+        "subProperties": [
+          {
+            "name": "生命值",
+            "value": "37",
+            "level": 1,
+            "valid": false,
+            "add": 0
+          },
+          {
+            "name": "暴击伤害",
+            "value": "1.6%",
+            "level": 1,
+            "valid": true,
+            "add": 0
+          }
+        ],
+        "suit": {
+          "name": "震星迪斯科",
+          "desc1": "冲击力+6%。",
+          "desc2": "[普通攻击]、[冲刺攻击]、[闪避反击]对主要攻击目标造成的失衡值提升20%。"
+        }
+      }
+    ]
+  }
+]</pre>
+            </div>
+
+            <div class="step">
+                <h3>❓ 常见问题</h3>
+                <p><strong>Q: 书签栏在哪里？</strong><br>
+                A: 浏览器顶部通常有一个书签栏。如果没有显示，按 <code>Ctrl+Shift+B</code> (Windows) 或 <code>Cmd+Shift+B</code> (Mac) 显示。</p>
+                
+                <p style="margin-top: 10px;"><strong>Q: 拖拽按钮到书签栏没有反应？</strong><br>
+                A: 可以右键点击按钮，选择"添加到书签"，然后手动添加到书签栏。</p>
+                
+                <p style="margin-top: 10px;"><strong>Q: 点击书签后没有反应？</strong><br>
+                A: 确保您在绝区零官方页面（act.mihoyo.com），并且已登录账号。</p>
+                
+                <p style="margin-top: 10px;"><strong>Q: 提取失败怎么办？</strong><br>
+                A: 检查网络连接，确认已登录，刷新页面后重试。</p>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // 检测是否在移动设备
+        if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            const mobileWarning = document.createElement('div');
+            mobileWarning.className = 'warning';
+            mobileWarning.innerHTML = '<strong>⚠️ 移动设备提示：</strong>书签脚本在移动设备上使用不便，建议使用电脑浏览器进行操作。';
+            document.querySelector('.content').insertBefore(mobileWarning, document.querySelector('.content').firstChild);
+        }
+
+        // 提供手动复制代码的功能
+        function showManualCode() {
+            const code = `(async function(){
+    const API_BASE = 'https://act-api-takumi.mihoyo.com/event/nap_cultivate_tool';
+    const API_LOGIN = 'https://api-takumi.mihoyo.com/common/badge/v1/login/info';
+    
+    const cleanText = t => t?.replace(/<[^>]*>/g, '').replace(/\\n/g, '') || '';
+    
+    const fetchJSON = (t, e) => fetch(t, {credentials: 'include', ...e}).then(t => t.json());
+    
+    const getGameUID = async () => (await fetchJSON(\`\${API_LOGIN}?game_biz=nap_cn&lang=zh-cn\`)).data?.game_uid;
+    
+    const getDeviceFP = () => document.cookie.match(/DEVICEFP=(\\w+)/)?.[1];
+    
+    const getBasicList = (t, e) => fetchJSON(\`\${API_BASE}/user/avatar_basic_list?uid=\${t}&region=prod_gf_cn\`, {
+        headers: {'x-rpc-device_fp': e}
+    });
+    
+    const getEquipBatch = (t, e, o) => fetchJSON(\`\${API_BASE}/user/batch_avatar_detail_v2?uid=\${t}&region=prod_gf_cn\`, {
+        method: 'POST',
+        headers: {'x-rpc-device_fp': o},
+        body: JSON.stringify({avatar_list: e})
+    });
+    
+    const processEquipData = ({avatar: t, equip: e, weapon: o}) => ({
+        characterName: t.name_mi18n,
+        characterFullName: t.full_name_mi18n,
+        level: t.level,
+        profession: t.avatar_profession,
+        driveDiscs: e?.map(({level: t, name: e, icon: o, rarity: a, invalid_property_cnt: i, equipment_type: s, properties: r, main_properties: n, equip_suit: c}) => ({
+            position: s,
+            name: e,
+            level: t,
+            rarity: a,
+            invalidProperty: i,
+            mainProperty: {name: n[0].property_name, val: n[0].base},
+            subProperties: r.map(({property_name: t, base: e, level: o, valid: a, add: i}) => ({
+                name: t, val: e, level: o, valid: a, add: i
+            })),
+            suit: {name: c.name, desc1: c.desc1, desc2: cleanText(c.desc2)}
+        })) || []
+    });
+    
+    const uid = await getGameUID();
+    const device_fp = getDeviceFP();
+    
+    if (!uid || !device_fp) {
+        alert('❌ 无法读取 UID 或 DEVICEFP，可能未登录！');
+        return;
+    }
+    
+    const basicData = await getBasicList(uid, device_fp);
+    const avatarList = basicData.data.list.filter(t => t.unlocked).map(t => ({avatar_id: t.avatar.id}));
+    
+    const batches = [];
+    for (let i = 0; i < avatarList.length; i += 10) {
+        batches.push(avatarList.slice(i, i + 10));
+    }
+    
+    const detailResponses = await Promise.all(batches.map(t => getEquipBatch(uid, t, device_fp)));
+    
+    const allResults = detailResponses.flatMap(t => t.data.list.map(processEquipData));
+    
+    const result = allResults.map(t => ({
+        characterName: t.characterName,
+        characterFullName: t.characterFullName,
+        level: t.level,
+        profession: t.profession,
+        driveDiscs: t.driveDiscs.map(e => ({
+            position: e.position,
+            name: e.name,
+            level: e.level,
+            rarity: e.rarity,
+            invalidProperty: e.invalidProperty,
+            mainProperty: {name: e.mainProperty.name, value: e.mainProperty.val},
+            subProperties: e.subProperties.map(t => ({
+                name: t.name, value: t.val, level: t.level, valid: t.valid, add: t.add
+            })),
+            suit: {name: e.suit.name, desc1: e.suit.desc1, desc2: e.suit.desc2}
+        }))
+    }));
+    
+    const jsonResult = JSON.stringify(result, null, 2);
+    const blob = new Blob([jsonResult], {type: 'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'drive_discs_data.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    
+    alert('✅ 驱动盘数据提取成功！已自动下载为 drive_discs_data.json');
+    console.log('📊 提取结果：', result);
+})();`;
+
+            const newWindow = window.open('', '_blank');
+            newWindow.document.write(`
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <title>手动复制代码</title>
+                    <style>
+                        body { font-family: monospace; padding: 20px; background: #f5f5f5; }
+                        pre { background: white; padding: 20px; border-radius: 8px; overflow-x: auto; }
+                        button { padding: 10px 20px; background: #667eea; color: white; border: none; border-radius: 4px; cursor: pointer; margin-top: 10px; }
+                        button:hover { background: #5568d3; }
+                    </style>
+                </head>
+                <body>
+                    <h2>复制以下代码到官方页面的控制台中：</h2>
+                    <pre>${code}</pre>
+                    <button onclick="navigator.clipboard.writeText(document.querySelector('pre').textContent); alert('已复制！')">复制代码</button>
+                </body>
+                </html>
+            `);
+        }
+    </script>
+</body>
+</html>

--- a/src/docs/tools/drive-disk-rating/requirements.txt
+++ b/src/docs/tools/drive-disk-rating/requirements.txt
@@ -1,0 +1,3 @@
+selenium
+webdriver-manager
+requests

--- a/src/docs/tools/drive-disk-rating/zzz_driver_disc_scraper.py
+++ b/src/docs/tools/drive-disk-rating/zzz_driver_disc_scraper.py
@@ -1,0 +1,297 @@
+from selenium import webdriver
+from selenium.webdriver.edge.service import Service
+from selenium.webdriver.edge.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+import json
+import os
+import sys
+
+class ZZZDriverDiscScraper:
+    def __init__(self, edgedriver_path=None):
+        # 配置Edge选项
+        self.edge_options = Options()
+        # 可以根据需要添加更多选项，如无头模式
+        # self.edge_options.add_argument('--headless')
+        self.edge_options.add_argument('--no-sandbox')
+        self.edge_options.add_argument('--disable-dev-shm-usage')
+        
+        # 初始化WebDriver
+        try:
+            if edgedriver_path and os.path.exists(edgedriver_path):
+                print(f"使用指定的EdgeDriver路径: {edgedriver_path}")
+                service = Service(edgedriver_path)
+            else:
+                print("尝试使用系统中的EdgeDriver...")
+                service = Service()  # 尝试自动查找
+                
+            self.driver = webdriver.Edge(
+                service=service,
+                options=self.edge_options
+            )
+            self.wait = WebDriverWait(self.driver, 10)
+        except Exception as e:
+            print(f"初始化WebDriver失败: {e}")
+            print("请确保已安装Edge浏览器，并下载对应版本的EdgeDriver")
+            print("可以从https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/下载")
+            sys.exit(1)
+    
+    def visit_website(self):
+        """访问目标网站"""
+        url = "https://act.mihoyo.com/zzz/gt/character-builder-h/index.html#/"
+        self.driver.get(url)
+        print(f"已访问: {url}")
+    
+    def handle_login(self):
+        """处理登录逻辑"""
+        print("请在浏览器中完成登录操作...")
+        # 等待用户登录完成
+        input("登录完成后按Enter键继续...")
+    
+    def scrape_driver_disc_data(self):
+        """使用API爬取驱动盘数据"""
+        print("开始使用API爬取驱动盘数据...")
+        import requests
+        import json
+        
+        # API配置
+        API_BASE = "https://act-api-takumi.mihoyo.com/event/nap_cultivate_tool"
+        API_LOGIN = "https://api-takumi.mihoyo.com/common/badge/v1/login/info"
+        
+        # 从Selenium获取cookies
+        cookies = self.driver.get_cookies()
+        cookie_dict = {cookie['name']: cookie['value'] for cookie in cookies}
+        
+        # 清理文本中的 HTML 标签与转义换行
+        def clean_text(text):
+            if not text:
+                return ""
+            import re
+            return re.sub(r'<[^>]*>', '', text).replace('\\n', '')
+        
+        # 包装requests为JSON解析
+        def fetch_json(url, options={}):
+            headers = options.get('headers', {})
+            method = options.get('method', 'GET')
+            data = options.get('data')
+            
+            response = requests.request(
+                method, 
+                url, 
+                headers=headers, 
+                data=data,
+                cookies=cookie_dict
+            )
+            response.raise_for_status()
+            return response.json()
+        
+        # 获取当前登录账号UID
+        def get_game_uid():
+            url = f"{API_LOGIN}?game_biz=nap_cn&lang=zh-cn"
+            data = fetch_json(url)
+            return data.get('data', {}).get('game_uid')
+        
+        # 从cookie获取设备指纹
+        def get_device_fp():
+            return cookie_dict.get('DEVICEFP')
+        
+        # 获取基础角色列表
+        def get_basic_list(uid, fp):
+            url = f"{API_BASE}/user/avatar_basic_list?uid={uid}&region=prod_gf_cn"
+            headers = {"x-rpc-device_fp": fp}
+            return fetch_json(url, {"headers": headers})
+        
+        # 分批请求角色详情每批最多10个
+        def get_equip_batch(uid, batch, fp):
+            url = f"{API_BASE}/user/batch_avatar_detail_v2?uid={uid}&region=prod_gf_cn"
+            headers = {"x-rpc-device_fp": fp, "Content-Type": "application/json"}
+            data = json.dumps({"avatar_list": batch})
+            return fetch_json(url, {
+                "method": "POST",
+                "headers": headers,
+                "data": data
+            })
+        
+        # 数据清洗逻辑
+        def process_equip_data(item):
+            avatar = item.get('avatar', {})
+            equip = item.get('equip', [])
+            weapon = item.get('weapon')
+            
+            return {
+                # 角色基础信息
+                'role': {
+                    'level': avatar.get('level'),
+                    'name': avatar.get('name_mi18n'),
+                    'full_name': avatar.get('full_name_mi18n'),
+                    'camp_name': avatar.get('camp_name_mi18n'),
+                    'profession': avatar.get('avatar_profession'),
+                    'rarity': avatar.get('rarity'),
+                    'group_icon': avatar.get('group_icon_path'),
+                    'avatar_icon': avatar.get('hollow_icon_path'),
+                    
+                    # 属性
+                    'properties': [
+                        {
+                            'name': prop.get('property_name'),
+                            'val': prop.get('final')
+                        } for prop in avatar.get('properties', [])
+                    ],
+                    
+                    # 潜能
+                    'ranks': [
+                        {
+                            'name': rank.get('name'),
+                            'desc': clean_text(rank.get('desc')),
+                            'unlocked': rank.get('is_unlocked')
+                        } for rank in avatar.get('ranks', [])
+                    ]
+                },
+                
+                # 驱动盘信息
+                'equips': [
+                    {
+                        'level': e.get('level'),
+                        'name': e.get('name'),
+                        'icon': e.get('icon'),
+                        'rarity': e.get('rarity'),
+                        'invalid_property': e.get('invalid_property_cnt'),
+                        'num': e.get('equipment_type'),
+                        
+                        # 子属性
+                        'properties': [
+                            {
+                                'name': prop.get('property_name'),
+                                'val': prop.get('base'),
+                                'level': prop.get('level'),
+                                'valid': prop.get('valid'),
+                                'add': prop.get('add')
+                            } for prop in e.get('properties', [])
+                        ],
+                        
+                        # 主属性
+                        'main_properties': {
+                            'name': e.get('main_properties', [{}])[0].get('property_name'),
+                            'val': e.get('main_properties', [{}])[0].get('base'),
+                            'level': e.get('main_properties', [{}])[0].get('level'),
+                            'valid': e.get('main_properties', [{}])[0].get('valid'),
+                            'add': e.get('main_properties', [{}])[0].get('add')
+                        },
+                        
+                        # 套装信息
+                        'suit': {
+                            'name': e.get('equip_suit', {}).get('name'),
+                            'desc1': e.get('equip_suit', {}).get('desc1'),
+                            'desc2': clean_text(e.get('equip_suit', {}).get('desc2'))
+                        }
+                    } for e in equip
+                ],
+                
+                # 音擎信息
+                'weapon': weapon and {
+                    'level': weapon.get('level'),
+                    'name': weapon.get('name'),
+                    'star': weapon.get('star'),
+                    'icon': weapon.get('icon'),
+                    'rarity': weapon.get('rarity'),
+                    'talent_title': weapon.get('talent_title'),
+                    'talent_content': clean_text(weapon.get('talent_content')),
+                    'profession': weapon.get('profession'),
+                    'property': weapon.get('properties', [{}])[0],
+                    'main_properties': weapon.get('main_properties', [{}])[0]
+                }
+            }
+        
+        try:
+            # 主流程开始
+            uid = get_game_uid()
+            device_fp = get_device_fp()
+            
+            if not uid or not device_fp:
+                print("❌ 无法读取UID或DEVICEFP，可能未登录！")
+                return {}
+            
+            print(f"🎮 当前登录UID: {uid}")
+            
+            # 获取基础角色列表
+            basic_data = get_basic_list(uid, device_fp)
+            
+            # 检查basic_data是否有效
+            if not basic_data:
+                print("❌ 获取角色列表失败，basic_data为空")
+                return {}
+            
+            # 检查返回数据结构
+            data = basic_data.get('data', {})
+            if not data:
+                print(f"❌ API返回数据结构异常: {json.dumps(basic_data, ensure_ascii=False)}")
+                return {}
+            
+            list_data = data.get('list', [])
+            if not isinstance(list_data, list):
+                print(f"❌ 角色列表不是预期的数组格式: {type(list_data)}")
+                return {}
+            
+            avatar_list = [
+                {'avatar_id': item.get('avatar', {}).get('id')}
+                for item in list_data
+                if item.get('unlocked')
+            ]
+            
+            print(f"已找到 {len(avatar_list)} 位已解锁角色，开始获取装备详情...")
+            
+            # 将角色ID分批，每批最多10个
+            batches = []
+            for i in range(0, len(avatar_list), 10):
+                batches.append(avatar_list[i:i+10])
+            
+            # 并发请求所有批次
+            all_results = []
+            for i, batch in enumerate(batches):
+                print(f"处理批次 {i+1}/{len(batches)}...")
+                batch_data = get_equip_batch(uid, batch, device_fp)
+                
+                # 清洗批次数据
+                processed_batch = [
+                    process_equip_data(item)
+                    for item in batch_data.get('data', {}).get('list', [])
+                ]
+                all_results.extend(processed_batch)
+            
+            print(f"🎉 已成功提取所有角色数据（共{len(all_results)}个角色）")
+            return all_results
+            
+        except Exception as e:
+            print(f"API调用失败: {e}")
+            import traceback
+            traceback.print_exc()
+            return {}
+    
+    def save_data(self, data, filename="driver_disc_data.json"):
+        """保存爬取的数据"""
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+        print(f"数据已保存到: {filename}")
+    
+    def close(self):
+        """关闭浏览器"""
+        self.driver.quit()
+        print("浏览器已关闭")
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Zenless Zone Zero 驱动盘数据爬取工具")
+    parser.add_argument("--edgedriver", help="EdgeDriver的路径")
+    args = parser.parse_args()
+    
+    scraper = ZZZDriverDiscScraper(edgedriver_path=args.edgedriver)
+    try:
+        scraper.visit_website()
+        scraper.handle_login()
+        data = scraper.scrape_driver_disc_data()
+        scraper.save_data(data)
+    finally:
+        scraper.close()


### PR DESCRIPTION
添加用于获取《绝区零》游戏角色驱动盘数据的工具，包括：
- Python脚本实现API调用方式获取数据
- 一键提取HTML书签工具
- 详细使用文档和说明
- 依赖文件requirements.txt
修改了部分文件，并成功运行
参考链接:https://doupoa.site/archives/885