### PR TITLE
build: 更新依赖项并调整配置

### DIFF
--- a/src/docs/.vitepress/config.mts
+++ b/src/docs/.vitepress/config.mts
@@ -49,14 +49,12 @@ export default defineConfig({
     image: {
       lazyLoading: true,
     },
-    markdown: {
-      container: {
-        tipLabel: "提示",
-        warningLabel: "警告",
-        dangerLabel: "危险",
-        infoLabel: "信息",
-        detailsLabel: "详细信息",
-      },
+    container: {
+      tipLabel: "提示",
+      warningLabel: "警告",
+      dangerLabel: "危险",
+      infoLabel: "信息",
+      detailsLabel: "详细信息",
     },
   },
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -5,12 +5,12 @@
   "packages": {
     "": {
       "dependencies": {
-        "@types/node": "^25.0.0",
         "three": "^0.182.0"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.17",
+        "@types/node": "^25.0.9",
         "tailwindcss": "^4.1.17",
         "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-comment-with-giscus": "^1.1.15"
@@ -1359,10 +1359,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.0.0.tgz",
-      "integrity": "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==",
+      "version": "25.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.0.9.tgz",
+      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1889,6 +1891,7 @@
       "integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.3.0"
       }
@@ -2511,6 +2514,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2736,7 +2740,8 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -2790,6 +2795,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unist-util-is": {
@@ -2908,6 +2914,7 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3039,6 +3046,7 @@
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",

--- a/src/package.json
+++ b/src/package.json
@@ -7,12 +7,12 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.17",
+    "@types/node": "^25.0.9",
     "tailwindcss": "^4.1.17",
     "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-comment-with-giscus": "^1.1.15"
   },
   "dependencies": {
-    "@types/node": "^25.0.0",
     "three": "^0.182.0"
   }
 }


### PR DESCRIPTION
将 @types/node 从 dependencies 移动到 devDependencies 并升级到 ^25.0.9 调整 vitepress 配置中的 markdown 容器标签设置